### PR TITLE
fix(security): code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pages-test-deployment.yml
+++ b/.github/workflows/pages-test-deployment.yml
@@ -1,4 +1,6 @@
 name: Test deployment
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Fix for [https://github.com/SAP-docs/terraform-landingpage-for-btp/security/code-scanning/1](https://github.com/SAP-docs/terraform-landingpage-for-btp/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is the minimal permission required for the workflow to function correctly. This ensures that the workflow cannot perform any unintended actions that require write access.

The `permissions` block will be added immediately after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
